### PR TITLE
Support RawPath

### DIFF
--- a/rest-org.go
+++ b/rest-org.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // CreateOrg creates a new organization.
@@ -127,7 +128,9 @@ func (r *Client) GetOrgByOrgName(ctx context.Context, name string) (Org, error) 
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(ctx, fmt.Sprintf("api/orgs/name/%s", name), nil); err != nil {
+	path := fmt.Sprintf("api/orgs/name/%s", name)
+	rawPath := fmt.Sprintf("api/orgs/name/%s", url.PathEscape(name))
+	if raw, code, err = r.getWithRawPath(ctx, path, rawPath, nil); err != nil {
 		return org, err
 	}
 

--- a/rest-request.go
+++ b/rest-request.go
@@ -92,28 +92,35 @@ func NewClient(apiURL, apiKeyOrBasicAuth string, client *http.Client) *Client {
 }
 
 func (r *Client) get(ctx context.Context, query string, params url.Values) ([]byte, int, error) {
-	return r.doRequest(ctx, "GET", query, params, nil)
+	return r.doRequest(ctx, "GET", query, "", params, nil)
+}
+
+func (r *Client) getWithRawPath(ctx context.Context, query, rawPath string, params url.Values) ([]byte, int, error) {
+	return r.doRequest(ctx, "GET", query, rawPath, params, nil)
 }
 
 func (r *Client) patch(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest(ctx, "PATCH", query, params, bytes.NewBuffer(body))
+	return r.doRequest(ctx, "PATCH", query, "", params, bytes.NewBuffer(body))
 }
 
 func (r *Client) put(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest(ctx, "PUT", query, params, bytes.NewBuffer(body))
+	return r.doRequest(ctx, "PUT", query, "", params, bytes.NewBuffer(body))
 }
 
 func (r *Client) post(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest(ctx, "POST", query, params, bytes.NewBuffer(body))
+	return r.doRequest(ctx, "POST", query, "", params, bytes.NewBuffer(body))
 }
 
 func (r *Client) delete(ctx context.Context, query string) ([]byte, int, error) {
-	return r.doRequest(ctx, "DELETE", query, nil, nil)
+	return r.doRequest(ctx, "DELETE", query, "", nil, nil)
 }
 
-func (r *Client) doRequest(ctx context.Context, method, query string, params url.Values, buf io.Reader) ([]byte, int, error) {
+func (r *Client) doRequest(ctx context.Context, method, query, rawPath string, params url.Values, buf io.Reader) ([]byte, int, error) {
 	u, _ := url.Parse(r.baseURL)
 	u.Path = path.Join(u.Path, query)
+	if rawPath != "" {
+		u.RawPath = path.Join(u.RawPath, rawPath)
+	}
 	if params != nil {
 		u.RawQuery = params.Encode()
 	}


### PR DESCRIPTION
from the doc:
Path field is stored in decoded form: /%47%6f%2f becomes /Go/.
A consequence is that it is impossible to tell which slashes in the Path were
slashes in the raw URL and which were %2f. This distinction is rarely important,
but when it is, the code should use RawPath, an optional field which only gets
set if the default encoding is different from Path.

and because in the KKP we support names like - `¯\_(ツ)_/¯` :) we needs to be able to path RawPath with regular Path