### PR TITLE
add UserRole constant

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,30 @@
+package sdk
+
+/*
+   Copyright 2021 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ॐ तारे तुत्तारे तुरे स्व
+*/
+
+// RoleType is an alias for github.com/grafana/grafana/pkg/models.RoleType,
+// copied here to avoid having to introduce a dependency on Grafana, as
+// Grafana is not very Go-import-friendly.
+type RoleType string
+
+const (
+	ROLE_VIEWER RoleType = "Viewer"
+	ROLE_EDITOR RoleType = "Editor"
+	ROLE_ADMIN  RoleType = "Admin"
+)


### PR DESCRIPTION
Only github.com/grafana/grafana and none of the Go SDK's provide the constants for user roles. This makes it super annoying to use, because Grafana 6.1.7+ added a go.mod and became pratically unimportable without hacks.

To avoid having to introduce the dependency, this PR adds the constants to this SDK.